### PR TITLE
Only use basename of parameter file for job folder

### DIFF
--- a/python/evaluation_tools/run_experiment.py
+++ b/python/evaluation_tools/run_experiment.py
@@ -166,8 +166,8 @@ class Experiment(object):
             params[p_name] = p_current
             self.eval_dict['experiment_name'] = str(
                 experiment_basename + '/' + os.path.basename(dataset).replace(
-                    '.bag', '') + '__' + parameter_file.replace('.yaml', '') +
-                '__SWEEP_' + str(step))
+                    '.bag', '') + '__' + os.path.basename(parameter_file)
+                .replace('.yaml', '') + '__SWEEP_' + str(step))
 
             parameter_tag = str(parameter_file) + "_SWEEP_" + str(p_current)
             self.job_paths.append(
@@ -176,8 +176,9 @@ class Experiment(object):
             step += 1
         else:
           self.eval_dict['experiment_name'] = str(
-              experiment_basename + '/' + os.path.basename(dataset).replace(
-                  '.bag', '') + '__' + parameter_file.replace('.yaml', ''))
+              experiment_basename + '/' +
+              os.path.basename(dataset).replace('.bag', '') + '__' +
+              os.path.basename(parameter_file).replace('.yaml', ''))
 
           self.job_paths.append(
               self._createJobFolder(params, str(dataset), str(parameter_file)))


### PR DESCRIPTION
Avoid weird result folders in the style of `20180206_171213_wetrok_evaluation_4z_small/MH_01_easy__/home/eggerk/whatever/location/this/file/is/in/wetrok_parameters` and uses the much better `20180206_171213_wetrok_evaluation_4z_small/MH_01_easy__wetrok_parameters`.