### PR TITLE
Added forwarding executables for better install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ cs_add_library(${PROJECT_NAME} src/evaluation-data-collector.cc)
 
 cs_add_executable(dummy_app_for_unit_test src/test/dummy-app-for-unit-test.cc)
 
+# Add executables.
+cs_install_scripts(
+    scripts/dataset_tools
+    scripts/evaluation
+    scripts/job
+    scripts/run_experiment
+    scripts/simple_summarization
+)
+
 #########
 # TESTS #
 #########

--- a/python/evaluation_tools/dataset_tools.py
+++ b/python/evaluation_tools/dataset_tools.py
@@ -246,7 +246,7 @@ def downloadDataset(dataset_name):
     return getPathForDataset(dataset_name)
 
 
-if __name__ == '__main__':
+def main():
     usage = """
         List and download available Zurich-Eye datasets.
     """

--- a/python/evaluation_tools/evaluation.py
+++ b/python/evaluation_tools/evaluation.py
@@ -100,7 +100,7 @@ class Evaluation(object):
         return evaluation_script_results
 
 
-if __name__ == '__main__':
+def main():
 
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)

--- a/python/evaluation_tools/job.py
+++ b/python/evaluation_tools/job.py
@@ -395,7 +395,7 @@ class Job(object):
             summary_dict, stream=out_file_stream, default_flow_style=False)
 
 
-if __name__ == '__main__':
+def main():
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
 

--- a/python/evaluation_tools/run_experiment.py
+++ b/python/evaluation_tools/run_experiment.py
@@ -283,7 +283,7 @@ class Experiment(object):
             s.runSummarization()
 
 
-if __name__ == '__main__':
+def main():
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
     logger.info('Experiment started')

--- a/python/evaluation_tools/simple_summarization.py
+++ b/python/evaluation_tools/simple_summarization.py
@@ -371,7 +371,7 @@ class SimpleSummarization(object):
         return result_dict
 
 
-if __name__ == '__main__':
+def main():
 
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)

--- a/scripts/dataset_tools
+++ b/scripts/dataset_tools
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from evaluation_tools.dataset_tools import main
+
+if __name__ == '__main__':
+    main()

--- a/scripts/evaluation
+++ b/scripts/evaluation
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from evaluation_tools.evaluation import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/job
+++ b/scripts/job
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from evaluation_tools.job import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_experiment
+++ b/scripts/run_experiment
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from evaluation_tools.run_experiment import main
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simple_summarization
+++ b/scripts/simple_summarization
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from evaluation_tools.simple_summarization import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As per suggestion here: http://docs.ros.org/kinetic/api/catkin/html/howto/format2/installing_python.html

Though this is still unfit for deployment (because of how datasets are supposed to go into the evaluation_tools package location)